### PR TITLE
feat: add Draw and Shift

### DIFF
--- a/contracts/kleros.json
+++ b/contracts/kleros.json
@@ -225,14 +225,39 @@
 			},
 			{
 				"name": "_appeal",
-				"type": "uint8"
+				"type": "uint256"
 			},
 			{
 				"name": "_voteID",
-				"type": "uint8"
+				"type": "uint256"
 			}
 		],
 		"name": "Draw",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"name": "_address",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"name": "_disputeID",
+				"type": "uint256"
+			},
+			{
+				"name": "_tokenAmount",
+				"type": "int256"
+			},
+			{
+				"name": "_ETHAmount",
+				"type": "int256"
+			}
+		],
+		"name": "TokenAndETHShift",
 		"type": "event"
 	},
 	{

--- a/contracts/kleros.json
+++ b/contracts/kleros.json
@@ -1,310 +1,737 @@
 [
-	{
-		"constant": true,
-		"inputs": [
-			{
-				"name": "_disputeID",
-				"type": "uint256"
-			}
-		],
-		"name": "disputeStatus",
-		"outputs": [
-			{
-				"name": "status",
-				"type": "uint8"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"constant": true,
-		"inputs": [
-			{
-				"name": "_disputeID",
-				"type": "uint256"
-			}
-		],
-		"name": "currentRuling",
-		"outputs": [
-			{
-				"name": "ruling",
-				"type": "uint256"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"constant": false,
-		"inputs": [
-			{
-				"name": "_disputeID",
-				"type": "uint256"
-			},
-			{
-				"name": "_extraData",
-				"type": "bytes"
-			}
-		],
-		"name": "appeal",
-		"outputs": [],
-		"payable": true,
-		"stateMutability": "payable",
-		"type": "function"
-	},
-	{
-		"constant": true,
-		"inputs": [
-			{
-				"name": "_disputeID",
-				"type": "uint256"
-			}
-		],
-		"name": "appealPeriod",
-		"outputs": [
-			{
-				"name": "start",
-				"type": "uint256"
-			},
-			{
-				"name": "end",
-				"type": "uint256"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"constant": false,
-		"inputs": [
-			{
-				"name": "_choices",
-				"type": "uint256"
-			},
-			{
-				"name": "_extraData",
-				"type": "bytes"
-			}
-		],
-		"name": "createDispute",
-		"outputs": [
-			{
-				"name": "disputeID",
-				"type": "uint256"
-			}
-		],
-		"payable": true,
-		"stateMutability": "payable",
-		"type": "function"
-	},
-	{
-		"constant": true,
-		"inputs": [
-			{
-				"name": "_disputeID",
-				"type": "uint256"
-			},
-			{
-				"name": "_extraData",
-				"type": "bytes"
-			}
-		],
-		"name": "appealCost",
-		"outputs": [
-			{
-				"name": "fee",
-				"type": "uint256"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"constant": true,
-		"inputs": [
-			{
-				"name": "_extraData",
-				"type": "bytes"
-			}
-		],
-		"name": "arbitrationCost",
-		"outputs": [
-			{
-				"name": "fee",
-				"type": "uint256"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"name": "_disputeID",
-				"type": "uint256"
-			},
-			{
-				"indexed": true,
-				"name": "_arbitrable",
-				"type": "address"
-			}
-		],
-		"name": "DisputeCreation",
-		"type": "event"
-	},
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"name": "_disputeID",
-				"type": "uint256"
-			},
-			{
-				"indexed": true,
-				"name": "_arbitrable",
-				"type": "address"
-			}
-		],
-		"name": "AppealPossible",
-		"type": "event"
-	},
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"name": "_disputeID",
-				"type": "uint256"
-			},
-			{
-				"indexed": true,
-				"name": "_arbitrable",
-				"type": "address"
-			}
-		],
-		"name": "AppealDecision",
-		"type": "event"
-	},
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"name": "_disputeID",
-				"type": "uint256"
-			},
-			{
-				"name": "_period",
-				"type": "uint8"
-			}
-		],
-		"name": "NewPeriod",
-		"type": "event"
-	},
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"name": "_address",
-				"type": "address"
-			},
-			{
-				"indexed": true,
-				"name": "_disputeID",
-				"type": "uint256"
-			},
-			{
-				"name": "_appeal",
-				"type": "uint256"
-			},
-			{
-				"name": "_voteID",
-				"type": "uint256"
-			}
-		],
-		"name": "Draw",
-		"type": "event"
-	},
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"name": "_address",
-				"type": "address"
-			},
-			{
-				"indexed": true,
-				"name": "_disputeID",
-				"type": "uint256"
-			},
-			{
-				"name": "_tokenAmount",
-				"type": "int256"
-			},
-			{
-				"name": "_ETHAmount",
-				"type": "int256"
-			}
-		],
-		"name": "TokenAndETHShift",
-		"type": "event"
-	},
-	{
-		"constant": true,
-		"inputs": [
-		  {
-			"name": "",
-			"type": "uint256"
-		  }
-		],
-		"name": "disputes",
-		"outputs": [
-		  {
-			"name": "subcourtID",
-			"type": "uint96"
-		  },
-		  {
-			"name": "arbitrated",
-			"type": "address"
-		  },
-		  {
-			"name": "numberOfChoices",
-			"type": "uint256"
-		  },
-		  {
-			"name": "period",
-			"type": "uint8"
-		  },
-		  {
-			"name": "lastPeriodChange",
-			"type": "uint256"
-		  },
-		  {
-			"name": "drawsInRound",
-			"type": "uint256"
-		  },
-		  {
-			"name": "commitsInRound",
-			"type": "uint256"
-		  },
-		  {
-			"name": "ruled",
-			"type": "bool"
-		  }
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	}
+  {
+    "constant": false,
+    "inputs": [{ "name": "_pinakion", "type": "address" }],
+    "name": "changePinakion",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "RNBlock",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "disputesWithoutJurors",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "passPhase",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "governor",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "lastDelayedSetStake",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_disputeID", "type": "uint256" }],
+    "name": "disputeStatus",
+    "outputs": [{ "name": "status", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_disputeID", "type": "uint256" }],
+    "name": "passPeriod",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "maxDrawingTime",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_disputeID", "type": "uint256" }],
+    "name": "currentRuling",
+    "outputs": [{ "name": "ruling", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "", "type": "uint256" }],
+    "name": "courts",
+    "outputs": [
+      { "name": "parent", "type": "uint96" },
+      { "name": "hiddenVotes", "type": "bool" },
+      { "name": "minStake", "type": "uint256" },
+      { "name": "alpha", "type": "uint256" },
+      { "name": "feeForJuror", "type": "uint256" },
+      { "name": "jurorsForCourtJump", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_disputeID", "type": "uint256" },
+      { "name": "_appeal", "type": "uint256" },
+      { "name": "_iterations", "type": "uint256" }
+    ],
+    "name": "execute",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "ALPHA_DIVISOR",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_disputeID", "type": "uint256" },
+      { "name": "_voteIDs", "type": "uint256[]" },
+      { "name": "_choice", "type": "uint256" },
+      { "name": "_salt", "type": "uint256" }
+    ],
+    "name": "castVote",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_subcourtID", "type": "uint96" },
+      { "name": "_minStake", "type": "uint256" }
+    ],
+    "name": "changeSubcourtMinStake",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_subcourtID", "type": "uint96" }],
+    "name": "getSubcourt",
+    "outputs": [
+      { "name": "children", "type": "uint256[]" },
+      { "name": "timesPerPeriod", "type": "uint256[4]" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_disputeID", "type": "uint256" },
+      { "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "appeal",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_from", "type": "address" },
+      { "name": "_to", "type": "address" },
+      { "name": "_amount", "type": "uint256" }
+    ],
+    "name": "onTransfer",
+    "outputs": [{ "name": "allowed", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "", "type": "uint256" }],
+    "name": "disputes",
+    "outputs": [
+      { "name": "subcourtID", "type": "uint96" },
+      { "name": "arbitrated", "type": "address" },
+      { "name": "numberOfChoices", "type": "uint256" },
+      { "name": "period", "type": "uint8" },
+      { "name": "lastPeriodChange", "type": "uint256" },
+      { "name": "drawsInRound", "type": "uint256" },
+      { "name": "commitsInRound", "type": "uint256" },
+      { "name": "ruled", "type": "bool" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_subcourtID", "type": "uint96" },
+      { "name": "_timesPerPeriod", "type": "uint256[4]" }
+    ],
+    "name": "changeSubcourtTimesPerPeriod",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_subcourtID", "type": "uint96" },
+      { "name": "_feeForJuror", "type": "uint256" }
+    ],
+    "name": "changeSubcourtJurorFee",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_subcourtID", "type": "uint96" },
+      { "name": "_alpha", "type": "uint256" }
+    ],
+    "name": "changeSubcourtAlpha",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_disputeID", "type": "uint256" },
+      { "name": "_voteIDs", "type": "uint256[]" },
+      { "name": "_commit", "type": "bytes32" }
+    ],
+    "name": "castCommit",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "RN",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "RNGenerator",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_destination", "type": "address" },
+      { "name": "_amount", "type": "uint256" },
+      { "name": "_data", "type": "bytes" }
+    ],
+    "name": "executeGovernorProposal",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_minStakingTime", "type": "uint256" }],
+    "name": "changeMinStakingTime",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "NON_PAYABLE_AMOUNT",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_subcourtID", "type": "uint96" },
+      { "name": "_stake", "type": "uint128" }
+    ],
+    "name": "setStake",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_disputeID", "type": "uint256" }],
+    "name": "executeRuling",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "_disputeID", "type": "uint256" },
+      { "name": "_appeal", "type": "uint256" },
+      { "name": "_voteID", "type": "uint256" }
+    ],
+    "name": "getVote",
+    "outputs": [
+      { "name": "account", "type": "address" },
+      { "name": "commit", "type": "bytes32" },
+      { "name": "choice", "type": "uint256" },
+      { "name": "voted", "type": "bool" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_RNGenerator", "type": "address" }],
+    "name": "changeRNGenerator",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_iterations", "type": "uint256" }],
+    "name": "executeDelayedSetStakes",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "_account", "type": "address" },
+      { "name": "_subcourtID", "type": "uint96" }
+    ],
+    "name": "stakeOf",
+    "outputs": [{ "name": "stake", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_subcourtID", "type": "uint96" },
+      { "name": "_jurorsForCourtJump", "type": "uint256" }
+    ],
+    "name": "changeSubcourtJurorsForJump",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_disputeID", "type": "uint256" }],
+    "name": "appealPeriod",
+    "outputs": [
+      { "name": "start", "type": "uint256" },
+      { "name": "end", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "phase",
+    "outputs": [{ "name": "", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "MAX_STAKE_PATHS",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "", "type": "uint256" }],
+    "name": "delayedSetStakes",
+    "outputs": [
+      { "name": "account", "type": "address" },
+      { "name": "subcourtID", "type": "uint96" },
+      { "name": "stake", "type": "uint128" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "lastPhaseChange",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "minStakingTime",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "nextDelayedSetStake",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_numberOfChoices", "type": "uint256" },
+      { "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "createDispute",
+    "outputs": [{ "name": "disputeID", "type": "uint256" }],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_disputeID", "type": "uint256" },
+      { "name": "_iterations", "type": "uint256" }
+    ],
+    "name": "drawJurors",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_parent", "type": "uint96" },
+      { "name": "_hiddenVotes", "type": "bool" },
+      { "name": "_minStake", "type": "uint256" },
+      { "name": "_alpha", "type": "uint256" },
+      { "name": "_feeForJuror", "type": "uint256" },
+      { "name": "_jurorsForCourtJump", "type": "uint256" },
+      { "name": "_timesPerPeriod", "type": "uint256[4]" },
+      { "name": "_sortitionSumTreeK", "type": "uint256" }
+    ],
+    "name": "createSubcourt",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_account", "type": "address" }],
+    "name": "getJuror",
+    "outputs": [{ "name": "subcourtIDs", "type": "uint96[]" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_owner", "type": "address" },
+      { "name": "_spender", "type": "address" },
+      { "name": "_amount", "type": "uint256" }
+    ],
+    "name": "onApprove",
+    "outputs": [{ "name": "allowed", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "", "type": "address" }],
+    "name": "jurors",
+    "outputs": [
+      { "name": "stakedTokens", "type": "uint256" },
+      { "name": "lockedTokens", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_maxDrawingTime", "type": "uint256" }],
+    "name": "changeMaxDrawingTime",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_disputeID", "type": "uint256" }],
+    "name": "getDispute",
+    "outputs": [
+      { "name": "votesLengths", "type": "uint256[]" },
+      { "name": "tokensAtStakePerJuror", "type": "uint256[]" },
+      { "name": "totalFeesForJurors", "type": "uint256[]" },
+      { "name": "votesInEachRound", "type": "uint256[]" },
+      { "name": "repartitionsInEachRound", "type": "uint256[]" },
+      { "name": "penaltiesInEachRound", "type": "uint256[]" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "_disputeID", "type": "uint256" },
+      { "name": "_appeal", "type": "uint256" }
+    ],
+    "name": "getVoteCounter",
+    "outputs": [
+      { "name": "winningChoice", "type": "uint256" },
+      { "name": "counts", "type": "uint256[]" },
+      { "name": "tied", "type": "bool" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_governor", "type": "address" }],
+    "name": "changeGovernor",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "MIN_JURORS",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "_disputeID", "type": "uint256" },
+      { "name": "_extraData", "type": "bytes" }
+    ],
+    "name": "appealCost",
+    "outputs": [{ "name": "cost", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "_owner", "type": "address" }],
+    "name": "proxyPayment",
+    "outputs": [{ "name": "allowed", "type": "bool" }],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "lockInsolventTransfers",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_extraData", "type": "bytes" }],
+    "name": "arbitrationCost",
+    "outputs": [{ "name": "cost", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pinakion",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "name": "_governor", "type": "address" },
+      { "name": "_pinakion", "type": "address" },
+      { "name": "_RNGenerator", "type": "address" },
+      { "name": "_minStakingTime", "type": "uint256" },
+      { "name": "_maxDrawingTime", "type": "uint256" },
+      { "name": "_hiddenVotes", "type": "bool" },
+      { "name": "_minStake", "type": "uint256" },
+      { "name": "_alpha", "type": "uint256" },
+      { "name": "_feeForJuror", "type": "uint256" },
+      { "name": "_jurorsForCourtJump", "type": "uint256" },
+      { "name": "_timesPerPeriod", "type": "uint256[4]" },
+      { "name": "_sortitionSumTreeK", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "name": "_phase", "type": "uint8" }],
+    "name": "NewPhase",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "_disputeID", "type": "uint256" },
+      { "indexed": false, "name": "_period", "type": "uint8" }
+    ],
+    "name": "NewPeriod",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "_address", "type": "address" },
+      { "indexed": false, "name": "_subcourtID", "type": "uint256" },
+      { "indexed": false, "name": "_stake", "type": "uint128" },
+      { "indexed": false, "name": "_newTotalStake", "type": "uint256" }
+    ],
+    "name": "StakeSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "_address", "type": "address" },
+      { "indexed": true, "name": "_disputeID", "type": "uint256" },
+      { "indexed": false, "name": "_appeal", "type": "uint256" },
+      { "indexed": false, "name": "_voteID", "type": "uint256" }
+    ],
+    "name": "Draw",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "_address", "type": "address" },
+      { "indexed": true, "name": "_disputeID", "type": "uint256" },
+      { "indexed": false, "name": "_tokenAmount", "type": "int256" },
+      { "indexed": false, "name": "_ETHAmount", "type": "int256" }
+    ],
+    "name": "TokenAndETHShift",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "_disputeID", "type": "uint256" },
+      { "indexed": true, "name": "_arbitrable", "type": "address" }
+    ],
+    "name": "DisputeCreation",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "_disputeID", "type": "uint256" },
+      { "indexed": true, "name": "_arbitrable", "type": "address" }
+    ],
+    "name": "AppealPossible",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "_disputeID", "type": "uint256" },
+      { "indexed": true, "name": "_arbitrable", "type": "address" }
+    ],
+    "name": "AppealDecision",
+    "type": "event"
+  }
 ]

--- a/generated/Kleros/Kleros.ts
+++ b/generated/Kleros/Kleros.ts
@@ -119,12 +119,42 @@ export class Draw__Params {
     return this._event.parameters[1].value.toBigInt();
   }
 
-  get _appeal(): i32 {
-    return this._event.parameters[2].value.toI32();
+  get _appeal(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
   }
 
-  get _voteID(): i32 {
-    return this._event.parameters[3].value.toI32();
+  get _voteID(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+}
+
+export class TokenAndETHShift extends ethereum.Event {
+  get params(): TokenAndETHShift__Params {
+    return new TokenAndETHShift__Params(this);
+  }
+}
+
+export class TokenAndETHShift__Params {
+  _event: TokenAndETHShift;
+
+  constructor(event: TokenAndETHShift) {
+    this._event = event;
+  }
+
+  get _address(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get _disputeID(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
+  }
+
+  get _tokenAmount(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get _ETHAmount(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
   }
 }
 

--- a/generated/Kleros/Kleros.ts
+++ b/generated/Kleros/Kleros.ts
@@ -10,6 +10,136 @@ import {
   BigInt
 } from "@graphprotocol/graph-ts";
 
+export class NewPhase extends ethereum.Event {
+  get params(): NewPhase__Params {
+    return new NewPhase__Params(this);
+  }
+}
+
+export class NewPhase__Params {
+  _event: NewPhase;
+
+  constructor(event: NewPhase) {
+    this._event = event;
+  }
+
+  get _phase(): i32 {
+    return this._event.parameters[0].value.toI32();
+  }
+}
+
+export class NewPeriod extends ethereum.Event {
+  get params(): NewPeriod__Params {
+    return new NewPeriod__Params(this);
+  }
+}
+
+export class NewPeriod__Params {
+  _event: NewPeriod;
+
+  constructor(event: NewPeriod) {
+    this._event = event;
+  }
+
+  get _disputeID(): BigInt {
+    return this._event.parameters[0].value.toBigInt();
+  }
+
+  get _period(): i32 {
+    return this._event.parameters[1].value.toI32();
+  }
+}
+
+export class StakeSet extends ethereum.Event {
+  get params(): StakeSet__Params {
+    return new StakeSet__Params(this);
+  }
+}
+
+export class StakeSet__Params {
+  _event: StakeSet;
+
+  constructor(event: StakeSet) {
+    this._event = event;
+  }
+
+  get _address(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get _subcourtID(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
+  }
+
+  get _stake(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get _newTotalStake(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+}
+
+export class Draw extends ethereum.Event {
+  get params(): Draw__Params {
+    return new Draw__Params(this);
+  }
+}
+
+export class Draw__Params {
+  _event: Draw;
+
+  constructor(event: Draw) {
+    this._event = event;
+  }
+
+  get _address(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get _disputeID(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
+  }
+
+  get _appeal(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get _voteID(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+}
+
+export class TokenAndETHShift extends ethereum.Event {
+  get params(): TokenAndETHShift__Params {
+    return new TokenAndETHShift__Params(this);
+  }
+}
+
+export class TokenAndETHShift__Params {
+  _event: TokenAndETHShift;
+
+  constructor(event: TokenAndETHShift) {
+    this._event = event;
+  }
+
+  get _address(): Address {
+    return this._event.parameters[0].value.toAddress();
+  }
+
+  get _disputeID(): BigInt {
+    return this._event.parameters[1].value.toBigInt();
+  }
+
+  get _tokenAmount(): BigInt {
+    return this._event.parameters[2].value.toBigInt();
+  }
+
+  get _ETHAmount(): BigInt {
+    return this._event.parameters[3].value.toBigInt();
+  }
+}
+
 export class DisputeCreation extends ethereum.Event {
   get params(): DisputeCreation__Params {
     return new DisputeCreation__Params(this);
@@ -76,109 +206,87 @@ export class AppealDecision__Params {
   }
 }
 
-export class NewPeriod extends ethereum.Event {
-  get params(): NewPeriod__Params {
-    return new NewPeriod__Params(this);
-  }
-}
-
-export class NewPeriod__Params {
-  _event: NewPeriod;
-
-  constructor(event: NewPeriod) {
-    this._event = event;
-  }
-
-  get _disputeID(): BigInt {
-    return this._event.parameters[0].value.toBigInt();
-  }
-
-  get _period(): i32 {
-    return this._event.parameters[1].value.toI32();
-  }
-}
-
-export class Draw extends ethereum.Event {
-  get params(): Draw__Params {
-    return new Draw__Params(this);
-  }
-}
-
-export class Draw__Params {
-  _event: Draw;
-
-  constructor(event: Draw) {
-    this._event = event;
-  }
-
-  get _address(): Address {
-    return this._event.parameters[0].value.toAddress();
-  }
-
-  get _disputeID(): BigInt {
-    return this._event.parameters[1].value.toBigInt();
-  }
-
-  get _appeal(): BigInt {
-    return this._event.parameters[2].value.toBigInt();
-  }
-
-  get _voteID(): BigInt {
-    return this._event.parameters[3].value.toBigInt();
-  }
-}
-
-export class TokenAndETHShift extends ethereum.Event {
-  get params(): TokenAndETHShift__Params {
-    return new TokenAndETHShift__Params(this);
-  }
-}
-
-export class TokenAndETHShift__Params {
-  _event: TokenAndETHShift;
-
-  constructor(event: TokenAndETHShift) {
-    this._event = event;
-  }
-
-  get _address(): Address {
-    return this._event.parameters[0].value.toAddress();
-  }
-
-  get _disputeID(): BigInt {
-    return this._event.parameters[1].value.toBigInt();
-  }
-
-  get _tokenAmount(): BigInt {
-    return this._event.parameters[2].value.toBigInt();
-  }
-
-  get _ETHAmount(): BigInt {
-    return this._event.parameters[3].value.toBigInt();
-  }
-}
-
-export class Kleros__appealPeriodResult {
+export class Kleros__courtsResult {
   value0: BigInt;
-  value1: BigInt;
+  value1: boolean;
+  value2: BigInt;
+  value3: BigInt;
+  value4: BigInt;
+  value5: BigInt;
 
-  constructor(value0: BigInt, value1: BigInt) {
+  constructor(
+    value0: BigInt,
+    value1: boolean,
+    value2: BigInt,
+    value3: BigInt,
+    value4: BigInt,
+    value5: BigInt
+  ) {
+    this.value0 = value0;
+    this.value1 = value1;
+    this.value2 = value2;
+    this.value3 = value3;
+    this.value4 = value4;
+    this.value5 = value5;
+  }
+
+  toMap(): TypedMap<string, ethereum.Value> {
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0));
+    map.set("value1", ethereum.Value.fromBoolean(this.value1));
+    map.set("value2", ethereum.Value.fromUnsignedBigInt(this.value2));
+    map.set("value3", ethereum.Value.fromUnsignedBigInt(this.value3));
+    map.set("value4", ethereum.Value.fromUnsignedBigInt(this.value4));
+    map.set("value5", ethereum.Value.fromUnsignedBigInt(this.value5));
+    return map;
+  }
+
+  getParent(): BigInt {
+    return this.value0;
+  }
+
+  getHiddenVotes(): boolean {
+    return this.value1;
+  }
+
+  getMinStake(): BigInt {
+    return this.value2;
+  }
+
+  getAlpha(): BigInt {
+    return this.value3;
+  }
+
+  getFeeForJuror(): BigInt {
+    return this.value4;
+  }
+
+  getJurorsForCourtJump(): BigInt {
+    return this.value5;
+  }
+}
+
+export class Kleros__getSubcourtResult {
+  value0: Array<BigInt>;
+  value1: Array<BigInt>;
+
+  constructor(value0: Array<BigInt>, value1: Array<BigInt>) {
     this.value0 = value0;
     this.value1 = value1;
   }
 
   toMap(): TypedMap<string, ethereum.Value> {
     let map = new TypedMap<string, ethereum.Value>();
-    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0));
-    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    map.set("value0", ethereum.Value.fromUnsignedBigIntArray(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigIntArray(this.value1));
     return map;
   }
 
-  getStart(): BigInt {
+  getChildren(): Array<BigInt> {
     return this.value0;
   }
 
-  getEnd(): BigInt {
+  getTimesPerPeriod(): Array<BigInt> {
     return this.value1;
   }
 }
@@ -262,9 +370,298 @@ export class Kleros__disputesResult {
   }
 }
 
+export class Kleros__getVoteResult {
+  value0: Address;
+  value1: Bytes;
+  value2: BigInt;
+  value3: boolean;
+
+  constructor(value0: Address, value1: Bytes, value2: BigInt, value3: boolean) {
+    this.value0 = value0;
+    this.value1 = value1;
+    this.value2 = value2;
+    this.value3 = value3;
+  }
+
+  toMap(): TypedMap<string, ethereum.Value> {
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromAddress(this.value0));
+    map.set("value1", ethereum.Value.fromFixedBytes(this.value1));
+    map.set("value2", ethereum.Value.fromUnsignedBigInt(this.value2));
+    map.set("value3", ethereum.Value.fromBoolean(this.value3));
+    return map;
+  }
+
+  getAccount(): Address {
+    return this.value0;
+  }
+
+  getCommit(): Bytes {
+    return this.value1;
+  }
+
+  getChoice(): BigInt {
+    return this.value2;
+  }
+
+  getVoted(): boolean {
+    return this.value3;
+  }
+}
+
+export class Kleros__appealPeriodResult {
+  value0: BigInt;
+  value1: BigInt;
+
+  constructor(value0: BigInt, value1: BigInt) {
+    this.value0 = value0;
+    this.value1 = value1;
+  }
+
+  toMap(): TypedMap<string, ethereum.Value> {
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    return map;
+  }
+
+  getStart(): BigInt {
+    return this.value0;
+  }
+
+  getEnd(): BigInt {
+    return this.value1;
+  }
+}
+
+export class Kleros__delayedSetStakesResult {
+  value0: Address;
+  value1: BigInt;
+  value2: BigInt;
+
+  constructor(value0: Address, value1: BigInt, value2: BigInt) {
+    this.value0 = value0;
+    this.value1 = value1;
+    this.value2 = value2;
+  }
+
+  toMap(): TypedMap<string, ethereum.Value> {
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromAddress(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    map.set("value2", ethereum.Value.fromUnsignedBigInt(this.value2));
+    return map;
+  }
+
+  getAccount(): Address {
+    return this.value0;
+  }
+
+  getSubcourtID(): BigInt {
+    return this.value1;
+  }
+
+  getStake(): BigInt {
+    return this.value2;
+  }
+}
+
+export class Kleros__jurorsResult {
+  value0: BigInt;
+  value1: BigInt;
+
+  constructor(value0: BigInt, value1: BigInt) {
+    this.value0 = value0;
+    this.value1 = value1;
+  }
+
+  toMap(): TypedMap<string, ethereum.Value> {
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigInt(this.value1));
+    return map;
+  }
+
+  getStakedTokens(): BigInt {
+    return this.value0;
+  }
+
+  getLockedTokens(): BigInt {
+    return this.value1;
+  }
+}
+
+export class Kleros__getDisputeResult {
+  value0: Array<BigInt>;
+  value1: Array<BigInt>;
+  value2: Array<BigInt>;
+  value3: Array<BigInt>;
+  value4: Array<BigInt>;
+  value5: Array<BigInt>;
+
+  constructor(
+    value0: Array<BigInt>,
+    value1: Array<BigInt>,
+    value2: Array<BigInt>,
+    value3: Array<BigInt>,
+    value4: Array<BigInt>,
+    value5: Array<BigInt>
+  ) {
+    this.value0 = value0;
+    this.value1 = value1;
+    this.value2 = value2;
+    this.value3 = value3;
+    this.value4 = value4;
+    this.value5 = value5;
+  }
+
+  toMap(): TypedMap<string, ethereum.Value> {
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromUnsignedBigIntArray(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigIntArray(this.value1));
+    map.set("value2", ethereum.Value.fromUnsignedBigIntArray(this.value2));
+    map.set("value3", ethereum.Value.fromUnsignedBigIntArray(this.value3));
+    map.set("value4", ethereum.Value.fromUnsignedBigIntArray(this.value4));
+    map.set("value5", ethereum.Value.fromUnsignedBigIntArray(this.value5));
+    return map;
+  }
+
+  getVotesLengths(): Array<BigInt> {
+    return this.value0;
+  }
+
+  getTokensAtStakePerJuror(): Array<BigInt> {
+    return this.value1;
+  }
+
+  getTotalFeesForJurors(): Array<BigInt> {
+    return this.value2;
+  }
+
+  getVotesInEachRound(): Array<BigInt> {
+    return this.value3;
+  }
+
+  getRepartitionsInEachRound(): Array<BigInt> {
+    return this.value4;
+  }
+
+  getPenaltiesInEachRound(): Array<BigInt> {
+    return this.value5;
+  }
+}
+
+export class Kleros__getVoteCounterResult {
+  value0: BigInt;
+  value1: Array<BigInt>;
+  value2: boolean;
+
+  constructor(value0: BigInt, value1: Array<BigInt>, value2: boolean) {
+    this.value0 = value0;
+    this.value1 = value1;
+    this.value2 = value2;
+  }
+
+  toMap(): TypedMap<string, ethereum.Value> {
+    let map = new TypedMap<string, ethereum.Value>();
+    map.set("value0", ethereum.Value.fromUnsignedBigInt(this.value0));
+    map.set("value1", ethereum.Value.fromUnsignedBigIntArray(this.value1));
+    map.set("value2", ethereum.Value.fromBoolean(this.value2));
+    return map;
+  }
+
+  getWinningChoice(): BigInt {
+    return this.value0;
+  }
+
+  getCounts(): Array<BigInt> {
+    return this.value1;
+  }
+
+  getTied(): boolean {
+    return this.value2;
+  }
+}
+
 export class Kleros extends ethereum.SmartContract {
   static bind(address: Address): Kleros {
     return new Kleros("Kleros", address);
+  }
+
+  RNBlock(): BigInt {
+    let result = super.call("RNBlock", "RNBlock():(uint256)", []);
+
+    return result[0].toBigInt();
+  }
+
+  try_RNBlock(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall("RNBlock", "RNBlock():(uint256)", []);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  disputesWithoutJurors(): BigInt {
+    let result = super.call(
+      "disputesWithoutJurors",
+      "disputesWithoutJurors():(uint256)",
+      []
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_disputesWithoutJurors(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "disputesWithoutJurors",
+      "disputesWithoutJurors():(uint256)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  governor(): Address {
+    let result = super.call("governor", "governor():(address)", []);
+
+    return result[0].toAddress();
+  }
+
+  try_governor(): ethereum.CallResult<Address> {
+    let result = super.tryCall("governor", "governor():(address)", []);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
+  }
+
+  lastDelayedSetStake(): BigInt {
+    let result = super.call(
+      "lastDelayedSetStake",
+      "lastDelayedSetStake():(uint256)",
+      []
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_lastDelayedSetStake(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "lastDelayedSetStake",
+      "lastDelayedSetStake():(uint256)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   disputeStatus(_disputeID: BigInt): i32 {
@@ -286,6 +683,25 @@ export class Kleros extends ethereum.SmartContract {
     }
     let value = result.value;
     return ethereum.CallResult.fromValue(value[0].toI32());
+  }
+
+  maxDrawingTime(): BigInt {
+    let result = super.call("maxDrawingTime", "maxDrawingTime():(uint256)", []);
+
+    return result[0].toBigInt();
+  }
+
+  try_maxDrawingTime(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "maxDrawingTime",
+      "maxDrawingTime():(uint256)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   currentRuling(_disputeID: BigInt): BigInt {
@@ -311,60 +727,56 @@ export class Kleros extends ethereum.SmartContract {
     return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
-  appealPeriod(_disputeID: BigInt): Kleros__appealPeriodResult {
+  courts(param0: BigInt): Kleros__courtsResult {
     let result = super.call(
-      "appealPeriod",
-      "appealPeriod(uint256):(uint256,uint256)",
-      [ethereum.Value.fromUnsignedBigInt(_disputeID)]
+      "courts",
+      "courts(uint256):(uint96,bool,uint256,uint256,uint256,uint256)",
+      [ethereum.Value.fromUnsignedBigInt(param0)]
     );
 
-    return new Kleros__appealPeriodResult(
+    return new Kleros__courtsResult(
       result[0].toBigInt(),
-      result[1].toBigInt()
+      result[1].toBoolean(),
+      result[2].toBigInt(),
+      result[3].toBigInt(),
+      result[4].toBigInt(),
+      result[5].toBigInt()
     );
   }
 
-  try_appealPeriod(
-    _disputeID: BigInt
-  ): ethereum.CallResult<Kleros__appealPeriodResult> {
+  try_courts(param0: BigInt): ethereum.CallResult<Kleros__courtsResult> {
     let result = super.tryCall(
-      "appealPeriod",
-      "appealPeriod(uint256):(uint256,uint256)",
-      [ethereum.Value.fromUnsignedBigInt(_disputeID)]
+      "courts",
+      "courts(uint256):(uint96,bool,uint256,uint256,uint256,uint256)",
+      [ethereum.Value.fromUnsignedBigInt(param0)]
     );
     if (result.reverted) {
       return new ethereum.CallResult();
     }
     let value = result.value;
     return ethereum.CallResult.fromValue(
-      new Kleros__appealPeriodResult(value[0].toBigInt(), value[1].toBigInt())
+      new Kleros__courtsResult(
+        value[0].toBigInt(),
+        value[1].toBoolean(),
+        value[2].toBigInt(),
+        value[3].toBigInt(),
+        value[4].toBigInt(),
+        value[5].toBigInt()
+      )
     );
   }
 
-  appealCost(_disputeID: BigInt, _extraData: Bytes): BigInt {
-    let result = super.call(
-      "appealCost",
-      "appealCost(uint256,bytes):(uint256)",
-      [
-        ethereum.Value.fromUnsignedBigInt(_disputeID),
-        ethereum.Value.fromBytes(_extraData)
-      ]
-    );
+  ALPHA_DIVISOR(): BigInt {
+    let result = super.call("ALPHA_DIVISOR", "ALPHA_DIVISOR():(uint256)", []);
 
     return result[0].toBigInt();
   }
 
-  try_appealCost(
-    _disputeID: BigInt,
-    _extraData: Bytes
-  ): ethereum.CallResult<BigInt> {
+  try_ALPHA_DIVISOR(): ethereum.CallResult<BigInt> {
     let result = super.tryCall(
-      "appealCost",
-      "appealCost(uint256,bytes):(uint256)",
-      [
-        ethereum.Value.fromUnsignedBigInt(_disputeID),
-        ethereum.Value.fromBytes(_extraData)
-      ]
+      "ALPHA_DIVISOR",
+      "ALPHA_DIVISOR():(uint256)",
+      []
     );
     if (result.reverted) {
       return new ethereum.CallResult();
@@ -373,27 +785,72 @@ export class Kleros extends ethereum.SmartContract {
     return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
-  arbitrationCost(_extraData: Bytes): BigInt {
+  getSubcourt(_subcourtID: BigInt): Kleros__getSubcourtResult {
     let result = super.call(
-      "arbitrationCost",
-      "arbitrationCost(bytes):(uint256)",
-      [ethereum.Value.fromBytes(_extraData)]
+      "getSubcourt",
+      "getSubcourt(uint96):(uint256[],uint256[4])",
+      [ethereum.Value.fromUnsignedBigInt(_subcourtID)]
     );
 
-    return result[0].toBigInt();
+    return new Kleros__getSubcourtResult(
+      result[0].toBigIntArray(),
+      result[1].toBigIntArray()
+    );
   }
 
-  try_arbitrationCost(_extraData: Bytes): ethereum.CallResult<BigInt> {
+  try_getSubcourt(
+    _subcourtID: BigInt
+  ): ethereum.CallResult<Kleros__getSubcourtResult> {
     let result = super.tryCall(
-      "arbitrationCost",
-      "arbitrationCost(bytes):(uint256)",
-      [ethereum.Value.fromBytes(_extraData)]
+      "getSubcourt",
+      "getSubcourt(uint96):(uint256[],uint256[4])",
+      [ethereum.Value.fromUnsignedBigInt(_subcourtID)]
     );
     if (result.reverted) {
       return new ethereum.CallResult();
     }
     let value = result.value;
-    return ethereum.CallResult.fromValue(value[0].toBigInt());
+    return ethereum.CallResult.fromValue(
+      new Kleros__getSubcourtResult(
+        value[0].toBigIntArray(),
+        value[1].toBigIntArray()
+      )
+    );
+  }
+
+  onTransfer(_from: Address, _to: Address, _amount: BigInt): boolean {
+    let result = super.call(
+      "onTransfer",
+      "onTransfer(address,address,uint256):(bool)",
+      [
+        ethereum.Value.fromAddress(_from),
+        ethereum.Value.fromAddress(_to),
+        ethereum.Value.fromUnsignedBigInt(_amount)
+      ]
+    );
+
+    return result[0].toBoolean();
+  }
+
+  try_onTransfer(
+    _from: Address,
+    _to: Address,
+    _amount: BigInt
+  ): ethereum.CallResult<boolean> {
+    let result = super.tryCall(
+      "onTransfer",
+      "onTransfer(address,address,uint256):(bool)",
+      [
+        ethereum.Value.fromAddress(_from),
+        ethereum.Value.fromAddress(_to),
+        ethereum.Value.fromUnsignedBigInt(_amount)
+      ]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
   }
 
   disputes(param0: BigInt): Kleros__disputesResult {
@@ -438,6 +895,771 @@ export class Kleros extends ethereum.SmartContract {
       )
     );
   }
+
+  RN(): BigInt {
+    let result = super.call("RN", "RN():(uint256)", []);
+
+    return result[0].toBigInt();
+  }
+
+  try_RN(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall("RN", "RN():(uint256)", []);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  RNGenerator(): Address {
+    let result = super.call("RNGenerator", "RNGenerator():(address)", []);
+
+    return result[0].toAddress();
+  }
+
+  try_RNGenerator(): ethereum.CallResult<Address> {
+    let result = super.tryCall("RNGenerator", "RNGenerator():(address)", []);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
+  }
+
+  NON_PAYABLE_AMOUNT(): BigInt {
+    let result = super.call(
+      "NON_PAYABLE_AMOUNT",
+      "NON_PAYABLE_AMOUNT():(uint256)",
+      []
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_NON_PAYABLE_AMOUNT(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "NON_PAYABLE_AMOUNT",
+      "NON_PAYABLE_AMOUNT():(uint256)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  getVote(
+    _disputeID: BigInt,
+    _appeal: BigInt,
+    _voteID: BigInt
+  ): Kleros__getVoteResult {
+    let result = super.call(
+      "getVote",
+      "getVote(uint256,uint256,uint256):(address,bytes32,uint256,bool)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_disputeID),
+        ethereum.Value.fromUnsignedBigInt(_appeal),
+        ethereum.Value.fromUnsignedBigInt(_voteID)
+      ]
+    );
+
+    return new Kleros__getVoteResult(
+      result[0].toAddress(),
+      result[1].toBytes(),
+      result[2].toBigInt(),
+      result[3].toBoolean()
+    );
+  }
+
+  try_getVote(
+    _disputeID: BigInt,
+    _appeal: BigInt,
+    _voteID: BigInt
+  ): ethereum.CallResult<Kleros__getVoteResult> {
+    let result = super.tryCall(
+      "getVote",
+      "getVote(uint256,uint256,uint256):(address,bytes32,uint256,bool)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_disputeID),
+        ethereum.Value.fromUnsignedBigInt(_appeal),
+        ethereum.Value.fromUnsignedBigInt(_voteID)
+      ]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(
+      new Kleros__getVoteResult(
+        value[0].toAddress(),
+        value[1].toBytes(),
+        value[2].toBigInt(),
+        value[3].toBoolean()
+      )
+    );
+  }
+
+  stakeOf(_account: Address, _subcourtID: BigInt): BigInt {
+    let result = super.call("stakeOf", "stakeOf(address,uint96):(uint256)", [
+      ethereum.Value.fromAddress(_account),
+      ethereum.Value.fromUnsignedBigInt(_subcourtID)
+    ]);
+
+    return result[0].toBigInt();
+  }
+
+  try_stakeOf(
+    _account: Address,
+    _subcourtID: BigInt
+  ): ethereum.CallResult<BigInt> {
+    let result = super.tryCall("stakeOf", "stakeOf(address,uint96):(uint256)", [
+      ethereum.Value.fromAddress(_account),
+      ethereum.Value.fromUnsignedBigInt(_subcourtID)
+    ]);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  appealPeriod(_disputeID: BigInt): Kleros__appealPeriodResult {
+    let result = super.call(
+      "appealPeriod",
+      "appealPeriod(uint256):(uint256,uint256)",
+      [ethereum.Value.fromUnsignedBigInt(_disputeID)]
+    );
+
+    return new Kleros__appealPeriodResult(
+      result[0].toBigInt(),
+      result[1].toBigInt()
+    );
+  }
+
+  try_appealPeriod(
+    _disputeID: BigInt
+  ): ethereum.CallResult<Kleros__appealPeriodResult> {
+    let result = super.tryCall(
+      "appealPeriod",
+      "appealPeriod(uint256):(uint256,uint256)",
+      [ethereum.Value.fromUnsignedBigInt(_disputeID)]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(
+      new Kleros__appealPeriodResult(value[0].toBigInt(), value[1].toBigInt())
+    );
+  }
+
+  phase(): i32 {
+    let result = super.call("phase", "phase():(uint8)", []);
+
+    return result[0].toI32();
+  }
+
+  try_phase(): ethereum.CallResult<i32> {
+    let result = super.tryCall("phase", "phase():(uint8)", []);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toI32());
+  }
+
+  MAX_STAKE_PATHS(): BigInt {
+    let result = super.call(
+      "MAX_STAKE_PATHS",
+      "MAX_STAKE_PATHS():(uint256)",
+      []
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_MAX_STAKE_PATHS(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "MAX_STAKE_PATHS",
+      "MAX_STAKE_PATHS():(uint256)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  delayedSetStakes(param0: BigInt): Kleros__delayedSetStakesResult {
+    let result = super.call(
+      "delayedSetStakes",
+      "delayedSetStakes(uint256):(address,uint96,uint128)",
+      [ethereum.Value.fromUnsignedBigInt(param0)]
+    );
+
+    return new Kleros__delayedSetStakesResult(
+      result[0].toAddress(),
+      result[1].toBigInt(),
+      result[2].toBigInt()
+    );
+  }
+
+  try_delayedSetStakes(
+    param0: BigInt
+  ): ethereum.CallResult<Kleros__delayedSetStakesResult> {
+    let result = super.tryCall(
+      "delayedSetStakes",
+      "delayedSetStakes(uint256):(address,uint96,uint128)",
+      [ethereum.Value.fromUnsignedBigInt(param0)]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(
+      new Kleros__delayedSetStakesResult(
+        value[0].toAddress(),
+        value[1].toBigInt(),
+        value[2].toBigInt()
+      )
+    );
+  }
+
+  lastPhaseChange(): BigInt {
+    let result = super.call(
+      "lastPhaseChange",
+      "lastPhaseChange():(uint256)",
+      []
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_lastPhaseChange(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "lastPhaseChange",
+      "lastPhaseChange():(uint256)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  minStakingTime(): BigInt {
+    let result = super.call("minStakingTime", "minStakingTime():(uint256)", []);
+
+    return result[0].toBigInt();
+  }
+
+  try_minStakingTime(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "minStakingTime",
+      "minStakingTime():(uint256)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  nextDelayedSetStake(): BigInt {
+    let result = super.call(
+      "nextDelayedSetStake",
+      "nextDelayedSetStake():(uint256)",
+      []
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_nextDelayedSetStake(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "nextDelayedSetStake",
+      "nextDelayedSetStake():(uint256)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  getJuror(_account: Address): Array<BigInt> {
+    let result = super.call("getJuror", "getJuror(address):(uint96[])", [
+      ethereum.Value.fromAddress(_account)
+    ]);
+
+    return result[0].toBigIntArray();
+  }
+
+  try_getJuror(_account: Address): ethereum.CallResult<Array<BigInt>> {
+    let result = super.tryCall("getJuror", "getJuror(address):(uint96[])", [
+      ethereum.Value.fromAddress(_account)
+    ]);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigIntArray());
+  }
+
+  onApprove(_owner: Address, _spender: Address, _amount: BigInt): boolean {
+    let result = super.call(
+      "onApprove",
+      "onApprove(address,address,uint256):(bool)",
+      [
+        ethereum.Value.fromAddress(_owner),
+        ethereum.Value.fromAddress(_spender),
+        ethereum.Value.fromUnsignedBigInt(_amount)
+      ]
+    );
+
+    return result[0].toBoolean();
+  }
+
+  try_onApprove(
+    _owner: Address,
+    _spender: Address,
+    _amount: BigInt
+  ): ethereum.CallResult<boolean> {
+    let result = super.tryCall(
+      "onApprove",
+      "onApprove(address,address,uint256):(bool)",
+      [
+        ethereum.Value.fromAddress(_owner),
+        ethereum.Value.fromAddress(_spender),
+        ethereum.Value.fromUnsignedBigInt(_amount)
+      ]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
+  }
+
+  jurors(param0: Address): Kleros__jurorsResult {
+    let result = super.call("jurors", "jurors(address):(uint256,uint256)", [
+      ethereum.Value.fromAddress(param0)
+    ]);
+
+    return new Kleros__jurorsResult(result[0].toBigInt(), result[1].toBigInt());
+  }
+
+  try_jurors(param0: Address): ethereum.CallResult<Kleros__jurorsResult> {
+    let result = super.tryCall("jurors", "jurors(address):(uint256,uint256)", [
+      ethereum.Value.fromAddress(param0)
+    ]);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(
+      new Kleros__jurorsResult(value[0].toBigInt(), value[1].toBigInt())
+    );
+  }
+
+  getDispute(_disputeID: BigInt): Kleros__getDisputeResult {
+    let result = super.call(
+      "getDispute",
+      "getDispute(uint256):(uint256[],uint256[],uint256[],uint256[],uint256[],uint256[])",
+      [ethereum.Value.fromUnsignedBigInt(_disputeID)]
+    );
+
+    return new Kleros__getDisputeResult(
+      result[0].toBigIntArray(),
+      result[1].toBigIntArray(),
+      result[2].toBigIntArray(),
+      result[3].toBigIntArray(),
+      result[4].toBigIntArray(),
+      result[5].toBigIntArray()
+    );
+  }
+
+  try_getDispute(
+    _disputeID: BigInt
+  ): ethereum.CallResult<Kleros__getDisputeResult> {
+    let result = super.tryCall(
+      "getDispute",
+      "getDispute(uint256):(uint256[],uint256[],uint256[],uint256[],uint256[],uint256[])",
+      [ethereum.Value.fromUnsignedBigInt(_disputeID)]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(
+      new Kleros__getDisputeResult(
+        value[0].toBigIntArray(),
+        value[1].toBigIntArray(),
+        value[2].toBigIntArray(),
+        value[3].toBigIntArray(),
+        value[4].toBigIntArray(),
+        value[5].toBigIntArray()
+      )
+    );
+  }
+
+  getVoteCounter(
+    _disputeID: BigInt,
+    _appeal: BigInt
+  ): Kleros__getVoteCounterResult {
+    let result = super.call(
+      "getVoteCounter",
+      "getVoteCounter(uint256,uint256):(uint256,uint256[],bool)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_disputeID),
+        ethereum.Value.fromUnsignedBigInt(_appeal)
+      ]
+    );
+
+    return new Kleros__getVoteCounterResult(
+      result[0].toBigInt(),
+      result[1].toBigIntArray(),
+      result[2].toBoolean()
+    );
+  }
+
+  try_getVoteCounter(
+    _disputeID: BigInt,
+    _appeal: BigInt
+  ): ethereum.CallResult<Kleros__getVoteCounterResult> {
+    let result = super.tryCall(
+      "getVoteCounter",
+      "getVoteCounter(uint256,uint256):(uint256,uint256[],bool)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_disputeID),
+        ethereum.Value.fromUnsignedBigInt(_appeal)
+      ]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(
+      new Kleros__getVoteCounterResult(
+        value[0].toBigInt(),
+        value[1].toBigIntArray(),
+        value[2].toBoolean()
+      )
+    );
+  }
+
+  MIN_JURORS(): BigInt {
+    let result = super.call("MIN_JURORS", "MIN_JURORS():(uint256)", []);
+
+    return result[0].toBigInt();
+  }
+
+  try_MIN_JURORS(): ethereum.CallResult<BigInt> {
+    let result = super.tryCall("MIN_JURORS", "MIN_JURORS():(uint256)", []);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  appealCost(_disputeID: BigInt, _extraData: Bytes): BigInt {
+    let result = super.call(
+      "appealCost",
+      "appealCost(uint256,bytes):(uint256)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_disputeID),
+        ethereum.Value.fromBytes(_extraData)
+      ]
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_appealCost(
+    _disputeID: BigInt,
+    _extraData: Bytes
+  ): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "appealCost",
+      "appealCost(uint256,bytes):(uint256)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_disputeID),
+        ethereum.Value.fromBytes(_extraData)
+      ]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  lockInsolventTransfers(): boolean {
+    let result = super.call(
+      "lockInsolventTransfers",
+      "lockInsolventTransfers():(bool)",
+      []
+    );
+
+    return result[0].toBoolean();
+  }
+
+  try_lockInsolventTransfers(): ethereum.CallResult<boolean> {
+    let result = super.tryCall(
+      "lockInsolventTransfers",
+      "lockInsolventTransfers():(bool)",
+      []
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBoolean());
+  }
+
+  arbitrationCost(_extraData: Bytes): BigInt {
+    let result = super.call(
+      "arbitrationCost",
+      "arbitrationCost(bytes):(uint256)",
+      [ethereum.Value.fromBytes(_extraData)]
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_arbitrationCost(_extraData: Bytes): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "arbitrationCost",
+      "arbitrationCost(bytes):(uint256)",
+      [ethereum.Value.fromBytes(_extraData)]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
+  }
+
+  pinakion(): Address {
+    let result = super.call("pinakion", "pinakion():(address)", []);
+
+    return result[0].toAddress();
+  }
+
+  try_pinakion(): ethereum.CallResult<Address> {
+    let result = super.tryCall("pinakion", "pinakion():(address)", []);
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toAddress());
+  }
+}
+
+export class ChangePinakionCall extends ethereum.Call {
+  get inputs(): ChangePinakionCall__Inputs {
+    return new ChangePinakionCall__Inputs(this);
+  }
+
+  get outputs(): ChangePinakionCall__Outputs {
+    return new ChangePinakionCall__Outputs(this);
+  }
+}
+
+export class ChangePinakionCall__Inputs {
+  _call: ChangePinakionCall;
+
+  constructor(call: ChangePinakionCall) {
+    this._call = call;
+  }
+
+  get _pinakion(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+}
+
+export class ChangePinakionCall__Outputs {
+  _call: ChangePinakionCall;
+
+  constructor(call: ChangePinakionCall) {
+    this._call = call;
+  }
+}
+
+export class PassPhaseCall extends ethereum.Call {
+  get inputs(): PassPhaseCall__Inputs {
+    return new PassPhaseCall__Inputs(this);
+  }
+
+  get outputs(): PassPhaseCall__Outputs {
+    return new PassPhaseCall__Outputs(this);
+  }
+}
+
+export class PassPhaseCall__Inputs {
+  _call: PassPhaseCall;
+
+  constructor(call: PassPhaseCall) {
+    this._call = call;
+  }
+}
+
+export class PassPhaseCall__Outputs {
+  _call: PassPhaseCall;
+
+  constructor(call: PassPhaseCall) {
+    this._call = call;
+  }
+}
+
+export class PassPeriodCall extends ethereum.Call {
+  get inputs(): PassPeriodCall__Inputs {
+    return new PassPeriodCall__Inputs(this);
+  }
+
+  get outputs(): PassPeriodCall__Outputs {
+    return new PassPeriodCall__Outputs(this);
+  }
+}
+
+export class PassPeriodCall__Inputs {
+  _call: PassPeriodCall;
+
+  constructor(call: PassPeriodCall) {
+    this._call = call;
+  }
+
+  get _disputeID(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+}
+
+export class PassPeriodCall__Outputs {
+  _call: PassPeriodCall;
+
+  constructor(call: PassPeriodCall) {
+    this._call = call;
+  }
+}
+
+export class ExecuteCall extends ethereum.Call {
+  get inputs(): ExecuteCall__Inputs {
+    return new ExecuteCall__Inputs(this);
+  }
+
+  get outputs(): ExecuteCall__Outputs {
+    return new ExecuteCall__Outputs(this);
+  }
+}
+
+export class ExecuteCall__Inputs {
+  _call: ExecuteCall;
+
+  constructor(call: ExecuteCall) {
+    this._call = call;
+  }
+
+  get _disputeID(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+
+  get _appeal(): BigInt {
+    return this._call.inputValues[1].value.toBigInt();
+  }
+
+  get _iterations(): BigInt {
+    return this._call.inputValues[2].value.toBigInt();
+  }
+}
+
+export class ExecuteCall__Outputs {
+  _call: ExecuteCall;
+
+  constructor(call: ExecuteCall) {
+    this._call = call;
+  }
+}
+
+export class CastVoteCall extends ethereum.Call {
+  get inputs(): CastVoteCall__Inputs {
+    return new CastVoteCall__Inputs(this);
+  }
+
+  get outputs(): CastVoteCall__Outputs {
+    return new CastVoteCall__Outputs(this);
+  }
+}
+
+export class CastVoteCall__Inputs {
+  _call: CastVoteCall;
+
+  constructor(call: CastVoteCall) {
+    this._call = call;
+  }
+
+  get _disputeID(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+
+  get _voteIDs(): Array<BigInt> {
+    return this._call.inputValues[1].value.toBigIntArray();
+  }
+
+  get _choice(): BigInt {
+    return this._call.inputValues[2].value.toBigInt();
+  }
+
+  get _salt(): BigInt {
+    return this._call.inputValues[3].value.toBigInt();
+  }
+}
+
+export class CastVoteCall__Outputs {
+  _call: CastVoteCall;
+
+  constructor(call: CastVoteCall) {
+    this._call = call;
+  }
+}
+
+export class ChangeSubcourtMinStakeCall extends ethereum.Call {
+  get inputs(): ChangeSubcourtMinStakeCall__Inputs {
+    return new ChangeSubcourtMinStakeCall__Inputs(this);
+  }
+
+  get outputs(): ChangeSubcourtMinStakeCall__Outputs {
+    return new ChangeSubcourtMinStakeCall__Outputs(this);
+  }
+}
+
+export class ChangeSubcourtMinStakeCall__Inputs {
+  _call: ChangeSubcourtMinStakeCall;
+
+  constructor(call: ChangeSubcourtMinStakeCall) {
+    this._call = call;
+  }
+
+  get _subcourtID(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+
+  get _minStake(): BigInt {
+    return this._call.inputValues[1].value.toBigInt();
+  }
+}
+
+export class ChangeSubcourtMinStakeCall__Outputs {
+  _call: ChangeSubcourtMinStakeCall;
+
+  constructor(call: ChangeSubcourtMinStakeCall) {
+    this._call = call;
+  }
 }
 
 export class AppealCall extends ethereum.Call {
@@ -474,6 +1696,414 @@ export class AppealCall__Outputs {
   }
 }
 
+export class OnTransferCall extends ethereum.Call {
+  get inputs(): OnTransferCall__Inputs {
+    return new OnTransferCall__Inputs(this);
+  }
+
+  get outputs(): OnTransferCall__Outputs {
+    return new OnTransferCall__Outputs(this);
+  }
+}
+
+export class OnTransferCall__Inputs {
+  _call: OnTransferCall;
+
+  constructor(call: OnTransferCall) {
+    this._call = call;
+  }
+
+  get _from(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+
+  get _to(): Address {
+    return this._call.inputValues[1].value.toAddress();
+  }
+
+  get _amount(): BigInt {
+    return this._call.inputValues[2].value.toBigInt();
+  }
+}
+
+export class OnTransferCall__Outputs {
+  _call: OnTransferCall;
+
+  constructor(call: OnTransferCall) {
+    this._call = call;
+  }
+
+  get allowed(): boolean {
+    return this._call.outputValues[0].value.toBoolean();
+  }
+}
+
+export class ChangeSubcourtTimesPerPeriodCall extends ethereum.Call {
+  get inputs(): ChangeSubcourtTimesPerPeriodCall__Inputs {
+    return new ChangeSubcourtTimesPerPeriodCall__Inputs(this);
+  }
+
+  get outputs(): ChangeSubcourtTimesPerPeriodCall__Outputs {
+    return new ChangeSubcourtTimesPerPeriodCall__Outputs(this);
+  }
+}
+
+export class ChangeSubcourtTimesPerPeriodCall__Inputs {
+  _call: ChangeSubcourtTimesPerPeriodCall;
+
+  constructor(call: ChangeSubcourtTimesPerPeriodCall) {
+    this._call = call;
+  }
+
+  get _subcourtID(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+
+  get _timesPerPeriod(): Array<BigInt> {
+    return this._call.inputValues[1].value.toBigIntArray();
+  }
+}
+
+export class ChangeSubcourtTimesPerPeriodCall__Outputs {
+  _call: ChangeSubcourtTimesPerPeriodCall;
+
+  constructor(call: ChangeSubcourtTimesPerPeriodCall) {
+    this._call = call;
+  }
+}
+
+export class ChangeSubcourtJurorFeeCall extends ethereum.Call {
+  get inputs(): ChangeSubcourtJurorFeeCall__Inputs {
+    return new ChangeSubcourtJurorFeeCall__Inputs(this);
+  }
+
+  get outputs(): ChangeSubcourtJurorFeeCall__Outputs {
+    return new ChangeSubcourtJurorFeeCall__Outputs(this);
+  }
+}
+
+export class ChangeSubcourtJurorFeeCall__Inputs {
+  _call: ChangeSubcourtJurorFeeCall;
+
+  constructor(call: ChangeSubcourtJurorFeeCall) {
+    this._call = call;
+  }
+
+  get _subcourtID(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+
+  get _feeForJuror(): BigInt {
+    return this._call.inputValues[1].value.toBigInt();
+  }
+}
+
+export class ChangeSubcourtJurorFeeCall__Outputs {
+  _call: ChangeSubcourtJurorFeeCall;
+
+  constructor(call: ChangeSubcourtJurorFeeCall) {
+    this._call = call;
+  }
+}
+
+export class ChangeSubcourtAlphaCall extends ethereum.Call {
+  get inputs(): ChangeSubcourtAlphaCall__Inputs {
+    return new ChangeSubcourtAlphaCall__Inputs(this);
+  }
+
+  get outputs(): ChangeSubcourtAlphaCall__Outputs {
+    return new ChangeSubcourtAlphaCall__Outputs(this);
+  }
+}
+
+export class ChangeSubcourtAlphaCall__Inputs {
+  _call: ChangeSubcourtAlphaCall;
+
+  constructor(call: ChangeSubcourtAlphaCall) {
+    this._call = call;
+  }
+
+  get _subcourtID(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+
+  get _alpha(): BigInt {
+    return this._call.inputValues[1].value.toBigInt();
+  }
+}
+
+export class ChangeSubcourtAlphaCall__Outputs {
+  _call: ChangeSubcourtAlphaCall;
+
+  constructor(call: ChangeSubcourtAlphaCall) {
+    this._call = call;
+  }
+}
+
+export class CastCommitCall extends ethereum.Call {
+  get inputs(): CastCommitCall__Inputs {
+    return new CastCommitCall__Inputs(this);
+  }
+
+  get outputs(): CastCommitCall__Outputs {
+    return new CastCommitCall__Outputs(this);
+  }
+}
+
+export class CastCommitCall__Inputs {
+  _call: CastCommitCall;
+
+  constructor(call: CastCommitCall) {
+    this._call = call;
+  }
+
+  get _disputeID(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+
+  get _voteIDs(): Array<BigInt> {
+    return this._call.inputValues[1].value.toBigIntArray();
+  }
+
+  get _commit(): Bytes {
+    return this._call.inputValues[2].value.toBytes();
+  }
+}
+
+export class CastCommitCall__Outputs {
+  _call: CastCommitCall;
+
+  constructor(call: CastCommitCall) {
+    this._call = call;
+  }
+}
+
+export class ExecuteGovernorProposalCall extends ethereum.Call {
+  get inputs(): ExecuteGovernorProposalCall__Inputs {
+    return new ExecuteGovernorProposalCall__Inputs(this);
+  }
+
+  get outputs(): ExecuteGovernorProposalCall__Outputs {
+    return new ExecuteGovernorProposalCall__Outputs(this);
+  }
+}
+
+export class ExecuteGovernorProposalCall__Inputs {
+  _call: ExecuteGovernorProposalCall;
+
+  constructor(call: ExecuteGovernorProposalCall) {
+    this._call = call;
+  }
+
+  get _destination(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+
+  get _amount(): BigInt {
+    return this._call.inputValues[1].value.toBigInt();
+  }
+
+  get _data(): Bytes {
+    return this._call.inputValues[2].value.toBytes();
+  }
+}
+
+export class ExecuteGovernorProposalCall__Outputs {
+  _call: ExecuteGovernorProposalCall;
+
+  constructor(call: ExecuteGovernorProposalCall) {
+    this._call = call;
+  }
+}
+
+export class ChangeMinStakingTimeCall extends ethereum.Call {
+  get inputs(): ChangeMinStakingTimeCall__Inputs {
+    return new ChangeMinStakingTimeCall__Inputs(this);
+  }
+
+  get outputs(): ChangeMinStakingTimeCall__Outputs {
+    return new ChangeMinStakingTimeCall__Outputs(this);
+  }
+}
+
+export class ChangeMinStakingTimeCall__Inputs {
+  _call: ChangeMinStakingTimeCall;
+
+  constructor(call: ChangeMinStakingTimeCall) {
+    this._call = call;
+  }
+
+  get _minStakingTime(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+}
+
+export class ChangeMinStakingTimeCall__Outputs {
+  _call: ChangeMinStakingTimeCall;
+
+  constructor(call: ChangeMinStakingTimeCall) {
+    this._call = call;
+  }
+}
+
+export class SetStakeCall extends ethereum.Call {
+  get inputs(): SetStakeCall__Inputs {
+    return new SetStakeCall__Inputs(this);
+  }
+
+  get outputs(): SetStakeCall__Outputs {
+    return new SetStakeCall__Outputs(this);
+  }
+}
+
+export class SetStakeCall__Inputs {
+  _call: SetStakeCall;
+
+  constructor(call: SetStakeCall) {
+    this._call = call;
+  }
+
+  get _subcourtID(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+
+  get _stake(): BigInt {
+    return this._call.inputValues[1].value.toBigInt();
+  }
+}
+
+export class SetStakeCall__Outputs {
+  _call: SetStakeCall;
+
+  constructor(call: SetStakeCall) {
+    this._call = call;
+  }
+}
+
+export class ExecuteRulingCall extends ethereum.Call {
+  get inputs(): ExecuteRulingCall__Inputs {
+    return new ExecuteRulingCall__Inputs(this);
+  }
+
+  get outputs(): ExecuteRulingCall__Outputs {
+    return new ExecuteRulingCall__Outputs(this);
+  }
+}
+
+export class ExecuteRulingCall__Inputs {
+  _call: ExecuteRulingCall;
+
+  constructor(call: ExecuteRulingCall) {
+    this._call = call;
+  }
+
+  get _disputeID(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+}
+
+export class ExecuteRulingCall__Outputs {
+  _call: ExecuteRulingCall;
+
+  constructor(call: ExecuteRulingCall) {
+    this._call = call;
+  }
+}
+
+export class ChangeRNGeneratorCall extends ethereum.Call {
+  get inputs(): ChangeRNGeneratorCall__Inputs {
+    return new ChangeRNGeneratorCall__Inputs(this);
+  }
+
+  get outputs(): ChangeRNGeneratorCall__Outputs {
+    return new ChangeRNGeneratorCall__Outputs(this);
+  }
+}
+
+export class ChangeRNGeneratorCall__Inputs {
+  _call: ChangeRNGeneratorCall;
+
+  constructor(call: ChangeRNGeneratorCall) {
+    this._call = call;
+  }
+
+  get _RNGenerator(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+}
+
+export class ChangeRNGeneratorCall__Outputs {
+  _call: ChangeRNGeneratorCall;
+
+  constructor(call: ChangeRNGeneratorCall) {
+    this._call = call;
+  }
+}
+
+export class ExecuteDelayedSetStakesCall extends ethereum.Call {
+  get inputs(): ExecuteDelayedSetStakesCall__Inputs {
+    return new ExecuteDelayedSetStakesCall__Inputs(this);
+  }
+
+  get outputs(): ExecuteDelayedSetStakesCall__Outputs {
+    return new ExecuteDelayedSetStakesCall__Outputs(this);
+  }
+}
+
+export class ExecuteDelayedSetStakesCall__Inputs {
+  _call: ExecuteDelayedSetStakesCall;
+
+  constructor(call: ExecuteDelayedSetStakesCall) {
+    this._call = call;
+  }
+
+  get _iterations(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+}
+
+export class ExecuteDelayedSetStakesCall__Outputs {
+  _call: ExecuteDelayedSetStakesCall;
+
+  constructor(call: ExecuteDelayedSetStakesCall) {
+    this._call = call;
+  }
+}
+
+export class ChangeSubcourtJurorsForJumpCall extends ethereum.Call {
+  get inputs(): ChangeSubcourtJurorsForJumpCall__Inputs {
+    return new ChangeSubcourtJurorsForJumpCall__Inputs(this);
+  }
+
+  get outputs(): ChangeSubcourtJurorsForJumpCall__Outputs {
+    return new ChangeSubcourtJurorsForJumpCall__Outputs(this);
+  }
+}
+
+export class ChangeSubcourtJurorsForJumpCall__Inputs {
+  _call: ChangeSubcourtJurorsForJumpCall;
+
+  constructor(call: ChangeSubcourtJurorsForJumpCall) {
+    this._call = call;
+  }
+
+  get _subcourtID(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+
+  get _jurorsForCourtJump(): BigInt {
+    return this._call.inputValues[1].value.toBigInt();
+  }
+}
+
+export class ChangeSubcourtJurorsForJumpCall__Outputs {
+  _call: ChangeSubcourtJurorsForJumpCall;
+
+  constructor(call: ChangeSubcourtJurorsForJumpCall) {
+    this._call = call;
+  }
+}
+
 export class CreateDisputeCall extends ethereum.Call {
   get inputs(): CreateDisputeCall__Inputs {
     return new CreateDisputeCall__Inputs(this);
@@ -491,7 +2121,7 @@ export class CreateDisputeCall__Inputs {
     this._call = call;
   }
 
-  get _choices(): BigInt {
+  get _numberOfChoices(): BigInt {
     return this._call.inputValues[0].value.toBigInt();
   }
 
@@ -509,5 +2139,307 @@ export class CreateDisputeCall__Outputs {
 
   get disputeID(): BigInt {
     return this._call.outputValues[0].value.toBigInt();
+  }
+}
+
+export class DrawJurorsCall extends ethereum.Call {
+  get inputs(): DrawJurorsCall__Inputs {
+    return new DrawJurorsCall__Inputs(this);
+  }
+
+  get outputs(): DrawJurorsCall__Outputs {
+    return new DrawJurorsCall__Outputs(this);
+  }
+}
+
+export class DrawJurorsCall__Inputs {
+  _call: DrawJurorsCall;
+
+  constructor(call: DrawJurorsCall) {
+    this._call = call;
+  }
+
+  get _disputeID(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+
+  get _iterations(): BigInt {
+    return this._call.inputValues[1].value.toBigInt();
+  }
+}
+
+export class DrawJurorsCall__Outputs {
+  _call: DrawJurorsCall;
+
+  constructor(call: DrawJurorsCall) {
+    this._call = call;
+  }
+}
+
+export class CreateSubcourtCall extends ethereum.Call {
+  get inputs(): CreateSubcourtCall__Inputs {
+    return new CreateSubcourtCall__Inputs(this);
+  }
+
+  get outputs(): CreateSubcourtCall__Outputs {
+    return new CreateSubcourtCall__Outputs(this);
+  }
+}
+
+export class CreateSubcourtCall__Inputs {
+  _call: CreateSubcourtCall;
+
+  constructor(call: CreateSubcourtCall) {
+    this._call = call;
+  }
+
+  get _parent(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+
+  get _hiddenVotes(): boolean {
+    return this._call.inputValues[1].value.toBoolean();
+  }
+
+  get _minStake(): BigInt {
+    return this._call.inputValues[2].value.toBigInt();
+  }
+
+  get _alpha(): BigInt {
+    return this._call.inputValues[3].value.toBigInt();
+  }
+
+  get _feeForJuror(): BigInt {
+    return this._call.inputValues[4].value.toBigInt();
+  }
+
+  get _jurorsForCourtJump(): BigInt {
+    return this._call.inputValues[5].value.toBigInt();
+  }
+
+  get _timesPerPeriod(): Array<BigInt> {
+    return this._call.inputValues[6].value.toBigIntArray();
+  }
+
+  get _sortitionSumTreeK(): BigInt {
+    return this._call.inputValues[7].value.toBigInt();
+  }
+}
+
+export class CreateSubcourtCall__Outputs {
+  _call: CreateSubcourtCall;
+
+  constructor(call: CreateSubcourtCall) {
+    this._call = call;
+  }
+}
+
+export class OnApproveCall extends ethereum.Call {
+  get inputs(): OnApproveCall__Inputs {
+    return new OnApproveCall__Inputs(this);
+  }
+
+  get outputs(): OnApproveCall__Outputs {
+    return new OnApproveCall__Outputs(this);
+  }
+}
+
+export class OnApproveCall__Inputs {
+  _call: OnApproveCall;
+
+  constructor(call: OnApproveCall) {
+    this._call = call;
+  }
+
+  get _owner(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+
+  get _spender(): Address {
+    return this._call.inputValues[1].value.toAddress();
+  }
+
+  get _amount(): BigInt {
+    return this._call.inputValues[2].value.toBigInt();
+  }
+}
+
+export class OnApproveCall__Outputs {
+  _call: OnApproveCall;
+
+  constructor(call: OnApproveCall) {
+    this._call = call;
+  }
+
+  get allowed(): boolean {
+    return this._call.outputValues[0].value.toBoolean();
+  }
+}
+
+export class ChangeMaxDrawingTimeCall extends ethereum.Call {
+  get inputs(): ChangeMaxDrawingTimeCall__Inputs {
+    return new ChangeMaxDrawingTimeCall__Inputs(this);
+  }
+
+  get outputs(): ChangeMaxDrawingTimeCall__Outputs {
+    return new ChangeMaxDrawingTimeCall__Outputs(this);
+  }
+}
+
+export class ChangeMaxDrawingTimeCall__Inputs {
+  _call: ChangeMaxDrawingTimeCall;
+
+  constructor(call: ChangeMaxDrawingTimeCall) {
+    this._call = call;
+  }
+
+  get _maxDrawingTime(): BigInt {
+    return this._call.inputValues[0].value.toBigInt();
+  }
+}
+
+export class ChangeMaxDrawingTimeCall__Outputs {
+  _call: ChangeMaxDrawingTimeCall;
+
+  constructor(call: ChangeMaxDrawingTimeCall) {
+    this._call = call;
+  }
+}
+
+export class ChangeGovernorCall extends ethereum.Call {
+  get inputs(): ChangeGovernorCall__Inputs {
+    return new ChangeGovernorCall__Inputs(this);
+  }
+
+  get outputs(): ChangeGovernorCall__Outputs {
+    return new ChangeGovernorCall__Outputs(this);
+  }
+}
+
+export class ChangeGovernorCall__Inputs {
+  _call: ChangeGovernorCall;
+
+  constructor(call: ChangeGovernorCall) {
+    this._call = call;
+  }
+
+  get _governor(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+}
+
+export class ChangeGovernorCall__Outputs {
+  _call: ChangeGovernorCall;
+
+  constructor(call: ChangeGovernorCall) {
+    this._call = call;
+  }
+}
+
+export class ProxyPaymentCall extends ethereum.Call {
+  get inputs(): ProxyPaymentCall__Inputs {
+    return new ProxyPaymentCall__Inputs(this);
+  }
+
+  get outputs(): ProxyPaymentCall__Outputs {
+    return new ProxyPaymentCall__Outputs(this);
+  }
+}
+
+export class ProxyPaymentCall__Inputs {
+  _call: ProxyPaymentCall;
+
+  constructor(call: ProxyPaymentCall) {
+    this._call = call;
+  }
+
+  get _owner(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+}
+
+export class ProxyPaymentCall__Outputs {
+  _call: ProxyPaymentCall;
+
+  constructor(call: ProxyPaymentCall) {
+    this._call = call;
+  }
+
+  get allowed(): boolean {
+    return this._call.outputValues[0].value.toBoolean();
+  }
+}
+
+export class ConstructorCall extends ethereum.Call {
+  get inputs(): ConstructorCall__Inputs {
+    return new ConstructorCall__Inputs(this);
+  }
+
+  get outputs(): ConstructorCall__Outputs {
+    return new ConstructorCall__Outputs(this);
+  }
+}
+
+export class ConstructorCall__Inputs {
+  _call: ConstructorCall;
+
+  constructor(call: ConstructorCall) {
+    this._call = call;
+  }
+
+  get _governor(): Address {
+    return this._call.inputValues[0].value.toAddress();
+  }
+
+  get _pinakion(): Address {
+    return this._call.inputValues[1].value.toAddress();
+  }
+
+  get _RNGenerator(): Address {
+    return this._call.inputValues[2].value.toAddress();
+  }
+
+  get _minStakingTime(): BigInt {
+    return this._call.inputValues[3].value.toBigInt();
+  }
+
+  get _maxDrawingTime(): BigInt {
+    return this._call.inputValues[4].value.toBigInt();
+  }
+
+  get _hiddenVotes(): boolean {
+    return this._call.inputValues[5].value.toBoolean();
+  }
+
+  get _minStake(): BigInt {
+    return this._call.inputValues[6].value.toBigInt();
+  }
+
+  get _alpha(): BigInt {
+    return this._call.inputValues[7].value.toBigInt();
+  }
+
+  get _feeForJuror(): BigInt {
+    return this._call.inputValues[8].value.toBigInt();
+  }
+
+  get _jurorsForCourtJump(): BigInt {
+    return this._call.inputValues[9].value.toBigInt();
+  }
+
+  get _timesPerPeriod(): Array<BigInt> {
+    return this._call.inputValues[10].value.toBigIntArray();
+  }
+
+  get _sortitionSumTreeK(): BigInt {
+    return this._call.inputValues[11].value.toBigInt();
+  }
+}
+
+export class ConstructorCall__Outputs {
+  _call: ConstructorCall;
+
+  constructor(call: ConstructorCall) {
+    this._call = call;
   }
 }

--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -330,6 +330,194 @@ export class Round extends Entity {
   }
 }
 
+export class Draw extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id != null, "Cannot save Draw entity without an ID");
+    if (id) {
+      assert(
+        id.kind == ValueKind.STRING,
+        `Entities of type Draw must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`
+      );
+      store.set("Draw", id.toString(), this);
+    }
+  }
+
+  static loadInBlock(id: string): Draw | null {
+    return changetype<Draw | null>(store.get_in_block("Draw", id));
+  }
+
+  static load(id: string): Draw | null {
+    return changetype<Draw | null>(store.get("Draw", id));
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toString();
+    }
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get address(): Bytes {
+    let value = this.get("address");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBytes();
+    }
+  }
+
+  set address(value: Bytes) {
+    this.set("address", Value.fromBytes(value));
+  }
+
+  get appeal(): BigInt {
+    let value = this.get("appeal");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set appeal(value: BigInt) {
+    this.set("appeal", Value.fromBigInt(value));
+  }
+
+  get disputeID(): BigInt {
+    let value = this.get("disputeID");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set disputeID(value: BigInt) {
+    this.set("disputeID", Value.fromBigInt(value));
+  }
+
+  get voteID(): BigInt {
+    let value = this.get("voteID");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set voteID(value: BigInt) {
+    this.set("voteID", Value.fromBigInt(value));
+  }
+}
+
+export class TokenAndETHShift extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id != null, "Cannot save TokenAndETHShift entity without an ID");
+    if (id) {
+      assert(
+        id.kind == ValueKind.STRING,
+        `Entities of type TokenAndETHShift must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`
+      );
+      store.set("TokenAndETHShift", id.toString(), this);
+    }
+  }
+
+  static loadInBlock(id: string): TokenAndETHShift | null {
+    return changetype<TokenAndETHShift | null>(
+      store.get_in_block("TokenAndETHShift", id)
+    );
+  }
+
+  static load(id: string): TokenAndETHShift | null {
+    return changetype<TokenAndETHShift | null>(
+      store.get("TokenAndETHShift", id)
+    );
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toString();
+    }
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get ETHAmount(): BigInt {
+    let value = this.get("ETHAmount");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set ETHAmount(value: BigInt) {
+    this.set("ETHAmount", Value.fromBigInt(value));
+  }
+
+  get address(): Bytes {
+    let value = this.get("address");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBytes();
+    }
+  }
+
+  set address(value: Bytes) {
+    this.set("address", Value.fromBytes(value));
+  }
+
+  get disputeID(): BigInt {
+    let value = this.get("disputeID");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set disputeID(value: BigInt) {
+    this.set("disputeID", Value.fromBigInt(value));
+  }
+
+  get tokenAmount(): BigInt {
+    let value = this.get("tokenAmount");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set tokenAmount(value: BigInt) {
+    this.set("tokenAmount", Value.fromBigInt(value));
+  }
+}
+
 export class EvidenceGroup extends Entity {
   constructor(id: Bytes) {
     super();

--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -518,6 +518,137 @@ export class TokenAndETHShift extends Entity {
   }
 }
 
+export class StakeSet extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id != null, "Cannot save StakeSet entity without an ID");
+    if (id) {
+      assert(
+        id.kind == ValueKind.STRING,
+        `Entities of type StakeSet must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`
+      );
+      store.set("StakeSet", id.toString(), this);
+    }
+  }
+
+  static loadInBlock(id: string): StakeSet | null {
+    return changetype<StakeSet | null>(store.get_in_block("StakeSet", id));
+  }
+
+  static load(id: string): StakeSet | null {
+    return changetype<StakeSet | null>(store.get("StakeSet", id));
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toString();
+    }
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get address(): Bytes {
+    let value = this.get("address");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBytes();
+    }
+  }
+
+  set address(value: Bytes) {
+    this.set("address", Value.fromBytes(value));
+  }
+
+  get subcourtID(): BigInt {
+    let value = this.get("subcourtID");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set subcourtID(value: BigInt) {
+    this.set("subcourtID", Value.fromBigInt(value));
+  }
+
+  get stake(): BigInt {
+    let value = this.get("stake");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set stake(value: BigInt) {
+    this.set("stake", Value.fromBigInt(value));
+  }
+
+  get newTotalStake(): BigInt {
+    let value = this.get("newTotalStake");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set newTotalStake(value: BigInt) {
+    this.set("newTotalStake", Value.fromBigInt(value));
+  }
+
+  get timestamp(): BigInt {
+    let value = this.get("timestamp");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set timestamp(value: BigInt) {
+    this.set("timestamp", Value.fromBigInt(value));
+  }
+
+  get blocknumber(): BigInt {
+    let value = this.get("blocknumber");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set blocknumber(value: BigInt) {
+    this.set("blocknumber", Value.fromBigInt(value));
+  }
+
+  get logIndex(): BigInt {
+    let value = this.get("logIndex");
+    if (!value || value.kind == ValueKind.NULL) {
+      throw new Error("Cannot return null for a required field.");
+    } else {
+      return value.toBigInt();
+    }
+  }
+
+  set logIndex(value: BigInt) {
+    this.set("logIndex", Value.fromBigInt(value));
+  }
+}
+
 export class EvidenceGroup extends Entity {
   constructor(id: Bytes) {
     super();

--- a/mappings/index.ts
+++ b/mappings/index.ts
@@ -5,6 +5,7 @@ import {
   NewPeriod as NewPeriodEv,
   Draw as DrawEv,
   TokenAndETHShift as TokenAndETHShiftEv,
+  StakeSet as StakeSetEv,
   Kleros,
 } from "../generated/Kleros/Kleros";
 import {
@@ -21,6 +22,7 @@ import {
   Evidence,
   EvidenceGroup,
   Round,
+  StakeSet,
   TokenAndETHShift,
 } from "../generated/schema";
 import { ADDRESS, ONE, ZERO, ZERO_B } from "./const";
@@ -162,6 +164,31 @@ export function handleTokenAndETHShift(ev: TokenAndETHShiftEv): void {
   shift.disputeID = ev.params._disputeID;
   shift.tokenAmount = ev.params._tokenAmount;
   shift.save();
+}
+
+export function handleStakeSet(ev: StakeSetEv): void {
+  // Keep rolling until we find a free ID
+  let i = 0;
+  while (true) {
+    const stakeSet = StakeSet.load(
+      `${ev.params._address.toHexString()}-${ev.params._subcourtID}-${i}`
+    );
+    if (stakeSet == null) break;
+    i++;
+  }
+
+  const stakeSet = new StakeSet(
+    `${ev.params._address.toHexString()}-${ev.params._subcourtID}-${i}`
+  );
+
+  stakeSet.address = ev.params._address;
+  stakeSet.subcourtID = ev.params._subcourtID;
+  stakeSet.stake = ev.params._stake;
+  stakeSet.newTotalStake = ev.params._newTotalStake;
+  stakeSet.timestamp = ev.block.timestamp;
+  stakeSet.blocknumber = ev.block.number;
+  stakeSet.logIndex = ev.logIndex;
+  stakeSet.save();
 }
 
 export function handleMetaEvidence(ev: MetaEvidenceEv): void {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "graph build",
     "gen": "graph codegen --output-dir generated",
-    "deploy-xdai": "mustache config/xdai.json subgraph.template.yaml > subgraph.yaml && mustache config/xdai.json mappings/const.template.ts > mappings/const.ts && yarn gen && graph deploy --product hosted-service andreimvp/kleros-display",
-    "deploy-mainnet": "mustache config/mainnet.json subgraph.template.yaml > subgraph.yaml && mustache config/mainnet.json mappings/const.template.ts > mappings/const.ts && yarn gen && graph deploy --product hosted-service andreimvp/kleros-display-mainnet"
+    "deploy-xdai": "mustache config/xdai.json subgraph.template.yaml > subgraph.yaml && mustache config/xdai.json mappings/const.template.ts > mappings/const.ts && yarn gen && graph deploy --product hosted-service greenlucid/kleros-display",
+    "deploy-mainnet": "mustache config/mainnet.json subgraph.template.yaml > subgraph.yaml && mustache config/mainnet.json mappings/const.template.ts > mappings/const.ts && yarn gen && graph deploy --product hosted-service greenlucid/kleros-display-mainnet"
   }
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -34,6 +34,28 @@ type Round @entity {
   jurors: [Bytes!]!
 }
 
+type Draw @entity {
+  "disputeID-appeal-voteID"
+  id: ID!
+  "Lucky juror who got drawn"
+  address: Bytes!
+  "Number of the round"
+  appeal: BigInt!
+  "Number of the dispute"
+  disputeID: BigInt!
+  "Number of the vote"
+  voteID: BigInt!
+}
+
+type TokenAndETHShift @entity {
+  "disputeId-address-(discriminator)"
+  id: ID!
+  ETHAmount: BigInt!
+  address: Bytes!
+  disputeID: BigInt!
+  tokenAmount: BigInt!
+}
+
 type EvidenceGroup @entity {
   id: Bytes!
   dispute: Dispute

--- a/schema.graphql
+++ b/schema.graphql
@@ -56,6 +56,18 @@ type TokenAndETHShift @entity {
   tokenAmount: BigInt!
 }
 
+type StakeSet @entity {
+  "address-subcourtId-(discriminator)"
+  id: ID!
+  address: Bytes!
+  subcourtID: BigInt!
+  stake: BigInt!
+  newTotalStake: BigInt!
+  timestamp: BigInt!
+  blocknumber: BigInt!
+  logIndex: BigInt!
+}
+
 type EvidenceGroup @entity {
   id: Bytes!
   dispute: Dispute

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -29,8 +29,10 @@ dataSources:
           handler: handleAppealDecision
         - event: NewPeriod(indexed uint256,uint8)
           handler: handleNewPeriod
-        - event: Draw(indexed address,indexed uint256,uint8,uint8)
+        - event: Draw(indexed address,indexed uint256,uint256,uint256)
           handler: handleDraw
+        - event: TokenAndETHShift(indexed address,indexed uint256,int256,int256)
+          handler: handleTokenAndETHShift
 templates:
   - name: Arbitrable
     kind: ethereum/contract

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -33,6 +33,8 @@ dataSources:
           handler: handleDraw
         - event: TokenAndETHShift(indexed address,indexed uint256,int256,int256)
           handler: handleTokenAndETHShift
+        - event: StakeSet(indexed address,uint256,uint128,uint256)
+          handler: handleStakeSet
 templates:
   - name: Arbitrable
     kind: ethereum/contract

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -5,11 +5,11 @@ schema:
 dataSources:
   - name: Kleros
     kind: ethereum
-    network: mainnet
+    network: xdai
     source:
-      address: "0x988b3a538b618c7a603e1c11ab82cd16dbe28069"
+      address: "0x9c1da9a04925bdfdedf0f6421bc7eea8305f9002"
       abi: Kleros
-      startBlock: 7303699
+      startBlock: 16895601
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -29,12 +29,14 @@ dataSources:
           handler: handleAppealDecision
         - event: NewPeriod(indexed uint256,uint8)
           handler: handleNewPeriod
-        - event: Draw(indexed address,indexed uint256,uint8,uint8)
+        - event: Draw(indexed address,indexed uint256,uint256,uint256)
           handler: handleDraw
+        - event: TokenAndETHShift(indexed address,indexed uint256,int256,int256)
+          handler: handleTokenAndETHShift
 templates:
   - name: Arbitrable
     kind: ethereum/contract
-    network: mainnet
+    network: xdai
     source:
       abi: Arbitrable
     mapping:

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -5,11 +5,11 @@ schema:
 dataSources:
   - name: Kleros
     kind: ethereum
-    network: xdai
+    network: mainnet
     source:
-      address: "0x9c1da9a04925bdfdedf0f6421bc7eea8305f9002"
+      address: "0x988b3a538b618c7a603e1c11ab82cd16dbe28069"
       abi: Kleros
-      startBlock: 16895601
+      startBlock: 7303699
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -33,10 +33,12 @@ dataSources:
           handler: handleDraw
         - event: TokenAndETHShift(indexed address,indexed uint256,int256,int256)
           handler: handleTokenAndETHShift
+        - event: StakeSet(indexed address,uint256,uint128,uint256)
+          handler: handleStakeSet
 templates:
   - name: Arbitrable
     kind: ethereum/contract
-    network: xdai
+    network: mainnet
     source:
       abi: Arbitrable
     mapping:


### PR DESCRIPTION
fixed a bug (uint8 -> uint256) somewhere

It wasn't convenient to rely on the `jurors` array on the Round:
- it doesn't have the roundId / appeal or anything ike that, which is needed in court frontend
- dupe jurors could be an issue when searching + performance concerns
- court frontend also needs voteID

these 2 entities don't reference anything, because they shouldn't need to